### PR TITLE
enhancement #437: updated logic of poll borders and semester dates:

### DIFF
--- a/prisma/migrations/20230617093017_correct_semesters_date/migration.sql
+++ b/prisma/migrations/20230617093017_correct_semesters_date/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - You are about to drop the `start_dates` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+
+ALTER TABLE "start_dates" RENAME TO "semester_dates";
+
+ALTER TABLE "semester_dates" RENAME CONSTRAINT "start_dates_pkey" TO "semester_dates_pkey";
+
+ALTER TABLE "semester_dates" ADD COLUMN "end_date" TIMESTAMP(3) NOT NULL DEFAULT '2023-01-01 00:00:00 +00:00';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -286,13 +286,14 @@ model Contact {
   @@map("contacts")
 }
 
-model StartDate {
+model SemesterDate {
   year      Int
   semester  Int
   startDate DateTime @map("start_date")
+  endDate   DateTime @map("end_date") @default("2023-01-01T00:00:00.000Z")
 
   @@id([year, semester])
-  @@map("start_dates")
+  @@map("semester_dates")
 }
 
 model DisciplineTeacherRole {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -5,10 +5,10 @@ const prisma = new PrismaClient();
 async function main () {
   console.log('Start seeding');
 
-  await prisma.startDate.createMany({
+  await prisma.semesterDate.createMany({
     data: [
-      { year: 2022, semester: 1, startDate: new Date('2023-09-10T00:00:00') },
-      { year: 2023, semester: 2, startDate: new Date('2023-02-10T00:00:00') },
+      { year: 2022, semester: 1, startDate: new Date('2022-09-05T00:00:00'), endDate: new Date('2023-01-23T00:00:00') },
+      { year: 2022, semester: 2, startDate: new Date('2023-02-05T00:00:00'), endDate: new Date('2023-06-26T00:00:00') },
     ],
   });
   console.log('Finished seeding');

--- a/src/v2/api/services/DisciplineTeacherService.ts
+++ b/src/v2/api/services/DisciplineTeacherService.ts
@@ -20,7 +20,6 @@ import { UserRepository } from '../../database/repositories/UserRepository';
 import { NoPermissionException } from '../../utils/exceptions/NoPermissionException';
 import { QuestionMapper } from '../../mappers/QuestionMapper';
 import { DbQuestionWithRoles } from '../../database/entities/DbQuestionWithRoles';
-import { DatabaseUtils } from '../../database/DatabaseUtils';
 
 @Injectable()
 export class DisciplineTeacherService {
@@ -166,9 +165,18 @@ export class DisciplineTeacherService {
   }
 
   async getPollTimeBorders () {
-    const { year, semester } = await this.dateService.getCurrentSemester();
-    const startPoll = await this.dateService.getDateVar(`START_POLL_${year}_${semester}`);
-    const endPoll = await this.dateService.getDateVar(`END_POLL_${year}_${semester}`);
+    const { year, semester, isFinished } = await this.dateService.getCurrentSemester();
+    let startPollName, endPollName;
+    if (isFinished) {
+      startPollName = `START_POLL_${year}_${semester}`;
+      endPollName = `END_POLL_${year}_${semester}`;
+    } else {
+      const previous = this.dateService.getPreviousSemester(semester, year);
+      startPollName = `START_POLL_${previous.year}_${previous.semester}`;
+      endPollName = `END_POLL_${previous.year}_${previous.semester}`;
+    }
+    const startPoll = await this.dateService.getDateVar(startPollName);
+    const endPoll = await this.dateService.getDateVar(endPollName);
     return {
       startPoll,
       endPoll,

--- a/src/v2/api/services/PollService.ts
+++ b/src/v2/api/services/PollService.ts
@@ -172,11 +172,11 @@ export class PollService {
       },
     });
 
-    const { semester, year } = await this.dateService.getCurrentSemester();
+    const semester = await this.dateService.getCurrentSemester();
 
     disciplines = disciplines.filter((discipline) => {
       return this.dateService.isPreviousSemester(
-        { semester, year },
+        semester,
         { semester: discipline.semester, year: discipline.year }
       );
     });

--- a/src/v2/utils/date/DateService.spec.ts
+++ b/src/v2/utils/date/DateService.spec.ts
@@ -20,12 +20,12 @@ describe('DateService', () => {
         .useFakeTimers()
         .setSystemTime(new Date('2023-06-06T00:00:00'));
       jest.spyOn(dateService, 'getCurrentSemester').mockImplementation(async () => (
-        { startDate: new Date('2023-02-05T00:00:00')} as any as Promise<CurrentSemester>
+        { startDate: new Date('2023-02-05T00:00:00') } as any as Promise<CurrentSemester>
       ));
 
       const result = await dateService.getCurrentDay();
 
-      expect(result).toStrictEqual({ fortnight: 9, week: 2, day: 2});
+      expect(result).toStrictEqual({ fortnight: 9, week: 2, day: 2 });
     });
 
     it('should return the 7th day if Sunday', async () => {
@@ -33,12 +33,12 @@ describe('DateService', () => {
         .useFakeTimers()
         .setSystemTime(new Date('2023-06-04T00:00:00'));
       jest.spyOn(dateService, 'getCurrentSemester').mockImplementation(async () => (
-        { startDate: new Date('2023-02-05T00:00:00')} as any as Promise<CurrentSemester>
+        { startDate: new Date('2023-02-05T00:00:00') } as any as Promise<CurrentSemester>
       ));
 
       const result = await dateService.getCurrentDay();
 
-      expect(result).toStrictEqual({ fortnight: 9, week: 1, day: 7});
+      expect(result).toStrictEqual({ fortnight: 9, week: 1, day: 7 });
     });
   });
 
@@ -48,7 +48,7 @@ describe('DateService', () => {
         .useFakeTimers()
         .setSystemTime(new Date('2023-06-06T00:00:00'));
       jest.spyOn(dateService, 'getCurrentSemester').mockImplementation(async () => (
-        { startDate: new Date('2023-02-05T00:00:00')} as any as Promise<CurrentSemester>
+        { startDate: new Date('2023-02-05T00:00:00') } as any as Promise<CurrentSemester>
       ));
 
       const result = await dateService.getCurrentWeek();
@@ -92,7 +92,7 @@ describe('DateService', () => {
   describe('isPreviousSemesterToCurrent', () => {
     it('should return true if the year is lower than current one', async () => {
       jest.spyOn(dateService, 'getCurrentSemester').mockImplementation(async () => (
-        { semester: 1, year: 3 } as any as Promise<CurrentSemester>
+        { semester: 1, year: 3, isFinished: false } as any as Promise<CurrentSemester>
       ));
 
       const semester = 2;
@@ -105,7 +105,7 @@ describe('DateService', () => {
 
     it('should return true if the semester is lower and the year is the same', async () => {
       jest.spyOn(dateService, 'getCurrentSemester').mockImplementation(async () => (
-        { semester: 2, year: 3 } as any as Promise<CurrentSemester>
+        { semester: 2, year: 3, isFinished: false } as any as Promise<CurrentSemester>
       ));
 
       const semester = 1;
@@ -118,7 +118,7 @@ describe('DateService', () => {
 
     it('should return false if the semester and year are larger than current one', async () => {
       jest.spyOn(dateService, 'getCurrentSemester').mockImplementation(async () => (
-        { semester: 1, year: 2 } as any as Promise<CurrentSemester>
+        { semester: 1, year: 2, isFinished: false } as any as Promise<CurrentSemester>
       ));
 
       const semester = 2;
@@ -127,6 +127,45 @@ describe('DateService', () => {
       const result = await dateService.isPreviousSemesterToCurrent(semester, year);
 
       expect(result).toBeFalsy();
+    });
+
+    it('should return true if current and comparing semesters are the same but current semester is finished', async () => {
+      jest.spyOn(dateService, 'getCurrentSemester').mockImplementation(async () => (
+        { semester: 1, year: 2, isFinished: true } as any as Promise<CurrentSemester>
+      ));
+
+      const semester = 1;
+      const year = 2;
+
+      const result = await dateService.isPreviousSemesterToCurrent(semester, year);
+
+      expect(result).toBeTruthy();
+    });
+  });
+
+  describe('getPreviousSemester', () => {
+    it('should return correct previous semester for the first semester', () => {
+      const semester = 1;
+      const year = 2023;
+
+      const result = dateService.getPreviousSemester(semester, year);
+
+      expect(result).toStrictEqual({
+        year: 2022,
+        semester: 2,
+      });
+    });
+
+    it('should return correct previous semester for the second semester', () => {
+      const semester = 2;
+      const year = 2023;
+
+      const result = dateService.getPreviousSemester(semester, year);
+
+      expect(result).toStrictEqual({
+        year: 2023,
+        semester: 1,
+      });
     });
   });
 });


### PR DESCRIPTION
- added method for getting previous semester value;
- changed logic of determining poll borders: if current semester is finished, then current poll borders takes, otherwise previous;
- added endDate for semesters;
- added new tests for new logic of DateService;
- changed seeding for database, fixing startDates;

closes #437