### PR TITLE
documentation #526: No parameters in Swagger

### DIFF
--- a/src/v2/api/controllers/DateController.ts
+++ b/src/v2/api/controllers/DateController.ts
@@ -1,10 +1,10 @@
 import { Controller, Get, Query } from '@nestjs/common';
 import { DateService } from '../../utils/date/DateService';
 import { ConvertToBooleanPipe } from '../pipes/ConvertToBooleanPipe';
-import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { ApiOkResponse, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { SemestersResponse } from '../responses/SemesterResponse';
 
-@ApiTags('Date')
+@ApiTags('Dates')
 @Controller({
   version: '2',
   path: '/dates',
@@ -17,6 +17,11 @@ export class DateController {
   @Get('/semesters')
   @ApiOkResponse({
     type: SemestersResponse,
+  })
+  @ApiQuery({
+    name: 'isFinished',
+    type: Boolean,
+    required: false,
   })
   async getPreviousSemesters (
     @Query('isFinished', ConvertToBooleanPipe) isFinished?


### PR DESCRIPTION
- changed name of ApiTags
- added parameter for /v2/dates/semesters to Swagger documentation

closes #526